### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pod "FluctSDK"
 # FluctSDK Release Note
 
 ## v4.3.2 2016/01/20
-* Swiftプロジェクト時のCocoapods利用でうまくImport出来ないバグの修正
+* Swiftプロジェクト時のCocoaPods利用でうまくImport出来ないバグの修正
 
 ## v4.3.1 2016/01/13
 * CocoaPodsに対応


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
