### PR TITLE
Remove `user_target_xcconfig` setting

### DIFF
--- a/FluctSDK.podspec
+++ b/FluctSDK.podspec
@@ -16,6 +16,5 @@ Pod::Spec.new do |s|
     s.weak_framework        = 'AppTrackingTransparency'
     s.libraries             = "xml2"
     s.pod_target_xcconfig   = { "EXCLUDED_ARCHS[sdk=iphonesimulator*]" => "arm64 arm64e armv7 armv7s", "EXCLUDED_ARCHS[sdk=iphoneos*]" => "i386 x86_64" }
-    s.user_target_xcconfig  = { "EXCLUDED_ARCHS[sdk=iphonesimulator*]" => "arm64 arm64e armv7 armv7s", "EXCLUDED_ARCHS[sdk=iphoneos*]" => "i386 x86_64" }
     s.cocoapods_version     = ">= 1.9.0"
 end


### PR DESCRIPTION
## Summary
こんにちは。現在FluctSDKを使用させて頂いておりますが、最新バージョン`6.13.12`において、`pod install`時に以下のようなwarningが出力されています。
```
[!] Can't merge user_target_xcconfig for pod targets: ["FluctSDK", "NendSDK_iOS"]. Singular build setting EXCLUDED_ARCHS[sdk=iphonesimulator*] has different values.
```
CocoaPodsのSyntaxReferenceには、`user_target_xcconfig`は非推奨の属性とされており、複数のpod間でこの設定が異なる場合に起こる警告のようです。つきましては`user_target_xcconfig`の削除を検討して頂けますと幸いです。

>This attribute is **not recommended** as Pods should not pollute the build settings of the user project and this can cause conflicts.

>Multiple definitions for build settings that take multiple values will be merged. The user is warned on conflicting definitions for custom build settings and build settings that take only one value.

>Typically clang compiler flags or precompiler macro definitions go in here if they are required when importing the pod in the user target. Note that, this influences not only the compiler view of the public interface of your pod, but also all other integrated pods alongside to yours. You should always prefer pod_target_xcconfig, which can contain the same settings, but only influence the toolchain when compiling your pod target.

cf: https://guides.cocoapods.org/syntax/podspec.html#user_target_xcconfig

---

この属性の使用による今回と同様の問題が以下で確認できます。
https://github.com/mopub/mopub-ios-sdk/pull/345
https://github.com/usabilla/usabilla-u4a-ios-swift-sdk/issues/219



